### PR TITLE
ENH: start / build scripts & UI adjustments

### DIFF
--- a/app/scripts/build.sh
+++ b/app/scripts/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+API_ENDPOINT=$(
+    aws cloudformation describe-stacks \
+        --stack-name FridgeTrackStack \
+        --query "Stacks[0].Outputs[?ExportName=='FridgeTrackAPIEndpoint'].OutputValue" \
+        --output text
+)
+REACT_APP_FRIDGE_TRACK_API_ENDPOINT=$API_ENDPOINT npm run build

--- a/app/scripts/start_local.sh
+++ b/app/scripts/start_local.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+API_ENDPOINT=$(
+    aws --endpoint-url=http://localhost:4566 cloudformation describe-stacks \
+        --stack-name FridgeTrackStack \
+        --query "Stacks[0].Outputs[?ExportName=='FridgeTrackAPIEndpoint'].OutputValue" \
+        --output text
+)
+REACT_APP_FRIDGE_TRACK_API_ENDPOINT=$API_ENDPOINT npm run start

--- a/app/src/components/Camera.js
+++ b/app/src/components/Camera.js
@@ -11,15 +11,13 @@ const useStyles = makeStyles((theme) => ({
         margin:'15px',
         minWidth: '300px',
         minHeight: '225px',
+        maxHeight: '300px',
     },
     videoPlayer: {
         width: '100%',
         height: '100%',
-        overflow: 'hidden',
-    },
-    videoPrompt: {
-        
-    },
+        overflow: 'hidden'
+    }
 }));
 
 
@@ -75,12 +73,11 @@ export default function Camera(props) {
 
         }
         return undefined;
-    }, []);
+    }, [history]);
 
     return (
         <div>
             <div className={classes.videoContainer}>
-            <div className={classes.videoPrompt}>Place the item's barcode in center of camera to scan</div>
             {videoError ?
                 <div>
                     <div>

--- a/app/src/components/FoodItemForm.js
+++ b/app/src/components/FoodItemForm.js
@@ -8,10 +8,15 @@ const useStyles = makeStyles((theme) => ({
     itemImageContainer: {
         textAlign: "center",
         maxHeight: "150px",
+        marginBottom: "10px"
     },
     formControl: {
-        marginBottom: "10px",
+        marginBottom: "10px"
     },
+    itemImage: {
+        maxHeight: "150px",
+        overflow: "hidden"
+    }
 }));
 
 
@@ -32,9 +37,9 @@ export default function FoodItemForm(props) {
         let endpoint;
         if(process.env['NODE_ENV'] && process.env['NODE_ENV'] === 'development') {
             const apiId = process.env.REACT_APP_FRIDGE_TRACK_API_ENDPOINT.split('.')[0].replace('https://', '');
-            endpoint = `http://localhost:4566/restapis/${apiId}/prod/_user_request_/items`
+            endpoint = `http://localhost:4566/restapis/${apiId}/prod/_user_request_/products`
         } else {
-            endpoint = `${process.env.REACT_APP_FRIDGE_TRACK_API_ENDPOINT}items`
+            endpoint = `${process.env.REACT_APP_FRIDGE_TRACK_API_ENDPOINT}products`
         }
         const data = {
             name: name,
@@ -57,6 +62,7 @@ export default function FoodItemForm(props) {
             {history?.location.state && history.location.state.status === 1 &&
                 <div className={classes.itemImageContainer}>
                     <img id="scanned-image" 
+                        className={classes.itemImage}
                         src={history.location.state?.data.product.selected_images.front.display.en} 
                         alt="Scanned item" 
                     />

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -8,8 +8,6 @@ import SearchAppBar from './components/AppBar';
 import { createTheme } from '@mui/material/styles';
 import { BrowserRouter as Router } from "react-router-dom";
 import AppContent from './components/AppContent';
-import AdapterDateFns from '@mui/lab/AdapterDateFns';
-import LocalizationProvider from '@mui/lab/LocalizationProvider';
 
 
 const theme = createTheme({
@@ -26,14 +24,12 @@ const theme = createTheme({
 
 ReactDOM.render(
   <React.StrictMode>
-    <LocalizationProvider dateAdapter={AdapterDateFns}>
-      <ThemeProvider theme={theme}>
-        <Router>
-          <SearchAppBar />
-          <AppContent />
-        </Router>
-      </ThemeProvider>
-    </LocalizationProvider>
+    <ThemeProvider theme={theme}>
+      <Router>
+        <SearchAppBar />
+        <AppContent />
+      </Router>
+    </ThemeProvider>
   </React.StrictMode>,
   document.getElementById('root')
 );

--- a/stack/bin/fridge-track-frontend.ts
+++ b/stack/bin/fridge-track-frontend.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 import 'source-map-support/register';
 import * as cdk from '@aws-cdk/core';
-import { FridgeTrackStack } from '../stack';
+import { FridgeTrackFrontendStack } from '../stack';
 
 const app = new cdk.App();
-new FridgeTrackStack(app, 'FridgeTrackStack', {
+new FridgeTrackFrontendStack(app, 'FridgeTrackFrontendStack', {
   /* If you don't specify 'env', this stack will be environment-agnostic.
    * Account/Region-dependent features and context lookups will not work,
    * but a single synthesized template can be deployed anywhere. */

--- a/stack/cdk.json
+++ b/stack/cdk.json
@@ -1,5 +1,5 @@
 {
-  "app": "npx ts-node --prefer-ts-exts bin/fridge-track.ts",
+  "app": "npx ts-node --prefer-ts-exts bin/fridge-track-frontend.ts",
   "context": {
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
     "@aws-cdk/core:enableStackNameDuplicates": "true",

--- a/stack/stack.ts
+++ b/stack/stack.ts
@@ -4,7 +4,7 @@ import { App, Stack, StackProps } from '@aws-cdk/core';
 import { Distribution } from '@aws-cdk/aws-cloudfront';
 import { S3Origin } from '@aws-cdk/aws-cloudfront-origins';
 
-export class FridgeTrackStack extends Stack {
+export class FridgeTrackFrontendStack extends Stack {
     constructor(scope: App, id: string, props?: StackProps) {
         super(scope, id, props);
 


### PR DESCRIPTION
Adds scripts for running locally (against localstack) and building. These use the `aws` command to query output variables from the backend CDK deployment, similarly to done in finance-dash. Using `aws` instead of `awslocal` now and should probably make the change elsewhere too.

Also includes some minor UI changes and fixing the endpoint route being called.